### PR TITLE
Upgrade to Java 21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
    </prerequisites>
    <properties>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-      <java.version>17</java.version>
+      <java.version>21</java.version>
       <project.build.javaVersion>${java.version}</project.build.javaVersion>
       <maven.compile.sourceLevel>${java.version}</maven.compile.sourceLevel>
       <maven.compile.targetLevel>${java.version}</maven.compile.targetLevel>


### PR DESCRIPTION
Resolves #2 — upgrades the project to **Java 21**.

### Change
- `pom.xml`: `java.version` `17` → `21` (the `maven.compile.sourceLevel`/`targetLevel` resolve from it).

### Verification
`mvn clean test` on **Temurin 21**: **125 tests, 0 failures, 0 errors** — identical to the Java 17 baseline. No source or dependency changes were needed.

---
🤖 Prepared with the [**bump-java-version**](https://github.com/vasiliy-mikhailov/bump-java-version-skill) skill — an OpenRewrite-based, conservation-verified Java LTS bump.
